### PR TITLE
feat: InterruptQueue-based async code review with flush guarantee

### DIFF
--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -88,6 +88,12 @@ function baseEventLine(event: AgentEvent): string {
       return `[${now()}] TOOL_RESULT step=${event.step} tool=${event.tool} ok=${event.ok}\n${shorten(event.output)}`
     case 'oscillation_observe':
       return `[${now()}] OSCILLATION_OBSERVE step=${event.step} window=${event.window} repeat_ratio=${event.repeatRatio} novelty_ratio=${event.noveltyRatio} no_mutation_steps=${event.noMutationSteps} possible=${event.possibleOscillation}`
+    case 'review_start':
+      return `[${now()}] REVIEW_START file=${event.file} linter=${event.linter}`
+    case 'review_pass':
+      return `[${now()}] REVIEW_PASS file=${event.file} linter=${event.linter}`
+    case 'review_fail':
+      return `[${now()}] REVIEW_FAIL file=${event.file} linter=${event.linter}\n${shorten(event.output)}`
     case 'final':
       return `[${now()}] FINAL step=${event.step}\n${shorten(event.content)}`
     case 'max_steps':

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -60,6 +60,12 @@ function baseEventLine(event: AgentEvent): string {
       return `[${now()}] TOOL_RESULT step=${event.step} tool=${event.tool} ok=${event.ok}\n${shorten(event.output)}`
     case 'oscillation_observe':
       return `[${now()}] OSCILLATION_OBSERVE step=${event.step} window=${event.window} repeat_ratio=${event.repeatRatio} novelty_ratio=${event.noveltyRatio} no_mutation_steps=${event.noMutationSteps} possible=${event.possibleOscillation}`
+    case 'review_start':
+      return `[${now()}] REVIEW_START file=${event.file} linter=${event.linter}`
+    case 'review_pass':
+      return `[${now()}] REVIEW_PASS file=${event.file} linter=${event.linter}`
+    case 'review_fail':
+      return `[${now()}] REVIEW_FAIL file=${event.file} linter=${event.linter}\n${shorten(event.output)}`
     case 'final':
       return `[${now()}] FINAL step=${event.step}\n${shorten(event.content)}`
     case 'max_steps':

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -32,6 +32,12 @@ export const appConfigSchema = z.object({
         })
         .default({})
     })
+    .default({}),
+  review: z
+    .object({
+      enabled: z.boolean().default(true),
+      tools: z.record(z.string(), z.string()).optional()
+    })
     .default({})
 }).transform((config) => ({
   ...config,

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -20,8 +20,10 @@ import {
   writeTextFile
 } from '../tools/filesystem.js'
 import {runShell} from '../tools/shell.js'
-import {AgentSession, InMemorySessionStore, type SessionSummaryBlock} from './session-store.js'
+import {AgentSession, InMemorySessionStore, type InterruptMessage, type ReviewConfig, type SessionSummaryBlock} from './session-store.js'
 import type {EventBus} from './event-bus.js'
+import {InterruptQueue} from './interrupt-queue.js'
+import {runCodeReview} from '../tools/code-review.js'
 import {loadUserProfileBrief} from './user-profile.js'
 import {checkGate} from './check-gate.js'
 
@@ -204,6 +206,9 @@ export type AgentEvent =
       noMutationSteps: number
       possibleOscillation: boolean
     }
+  | {type: 'review_start'; sessionId: string; step: number; file: string; linter: string}
+  | {type: 'review_pass'; sessionId: string; file: string; linter: string}
+  | {type: 'review_fail'; sessionId: string; file: string; linter: string; output: string}
   | {type: 'final'; sessionId: string; step: number; content: string}
   | {type: 'max_steps'; sessionId: string; step: number}
 
@@ -213,6 +218,7 @@ type AgentRunOptions = {
   maxSteps?: number
   contextWindowSize?: number
   onSensitiveAction?: (request: {tool: ToolName; command: string}) => Promise<boolean> | boolean
+  reviewConfig?: ReviewConfig
 }
 
 export type PersistedSessionSummary = {
@@ -756,10 +762,12 @@ export async function createAgentSession(options: AgentRunOptions = {}): Promise
       maxSteps: config.runtime.maxSteps,
       contextWindowSize: config.runtime.contextWindowSize
     },
+    reviewConfig: config.review,
     readPaths: new Set<string>(),
     summaries: [],
     compressedCount: 0,
-    messages: [{role: 'system', content: systemPrompt}]
+    messages: [{role: 'system', content: systemPrompt}],
+    interruptQueue: new InterruptQueue<InterruptMessage>()
   })
   created.logPath = getSessionLogPath(created.id, config.homeDir)
 
@@ -848,10 +856,12 @@ export async function resumeAgentSession(sessionId: string, options: AgentRunOpt
       maxSteps: config.runtime.maxSteps,
       contextWindowSize: config.runtime.contextWindowSize
     },
+    reviewConfig: config.review,
     readPaths: new Set<string>(),
     summaries: restoredSummaries,
     compressedCount,
-    messages: restoredMessages
+    messages: restoredMessages,
+    interruptQueue: new InterruptQueue<InterruptMessage>()
   })
 
   emitEvent(options, {type: 'session_resume', sessionId})
@@ -891,6 +901,11 @@ export async function runAgentTurn(
   emitEvent(options, {type: 'message', sessionId, role: 'user', content: userMessage})
 
   for (let step = 0; step < maxSteps; step += 1) {
+    const interrupts = session.interruptQueue.drain()
+    for (const msg of interrupts) {
+      session.messages.push(msg)
+      emitEvent(options, {type: 'message', sessionId, role: 'tool', step, content: msg.content, toolName: msg.toolName})
+    }
     const pendingCheckFailures = checkGate.popFailures(sessionId)
     for (const failure of pendingCheckFailures) {
       const toolContent = buildCheckToolMessage(failure.checker, failure.path, failure.output)
@@ -946,6 +961,14 @@ export async function runAgentTurn(
     const fallbackCalls = parseToolCalls(assistantText)
     const toolCalls: ToolCall[] = nativeCalls.length > 0 ? nativeCalls : fallbackCalls
     if (toolCalls.length === 0) {
+      const pendingReviews = await session.interruptQueue.flush()
+      if (pendingReviews.length > 0) {
+        for (const msg of pendingReviews) {
+          session.messages.push(msg)
+          emitEvent(options, {type: 'message', sessionId, role: 'tool', step, content: msg.content, toolName: msg.toolName})
+        }
+        continue
+      }
       emitEvent(options, {type: 'final', sessionId, step, content: assistantText})
       return assistantText
     }
@@ -1048,13 +1071,31 @@ export async function runAgentTurn(
         stepHasSuccessfulMutation = true
         workspaceVersion += 1
         explorationCounts.clear()
+        const filePath = String(toolCall.input.path ?? '')
         emitEvent(options, {
           type: 'write_completed',
           sessionId,
           step,
-          path: String(toolCall.input.path ?? ''),
+          path: filePath,
           tool: toolCall.tool
         })
+        const reviewCfg = options.reviewConfig ?? session.reviewConfig
+        if (reviewCfg.enabled) {
+          emitEvent(options, {type: 'review_start', sessionId, step, file: filePath, linter: 'auto'})
+          const reviewPromise = runCodeReview(filePath, session.workspace, reviewCfg).then((r) => {
+            if (r) {
+              emitEvent(options, {type: 'review_fail', sessionId, file: r.file, linter: r.linter, output: r.output})
+              return {
+                role: 'tool' as const,
+                content: `LINT_FAIL [${r.linter}] ${r.file}:\n${r.output}`,
+                toolName: 'code_review',
+              }
+            }
+            emitEvent(options, {type: 'review_pass', sessionId, file: filePath, linter: 'auto'})
+            return null
+          })
+          session.interruptQueue.enqueue(reviewPromise)
+        }
       }
     }
 

--- a/src/core/interrupt-queue.ts
+++ b/src/core/interrupt-queue.ts
@@ -1,0 +1,55 @@
+type PendingItem<T> = {
+  promise: Promise<T | null>
+  settled: boolean
+  value: T | null
+}
+
+/**
+ * Generic async interrupt queue.
+ *
+ * Callers enqueue promises that resolve to either a value (= interrupt needed)
+ * or null (= no action).  The agent loop can non-blockingly drain settled
+ * results or blocking-flush all pending items before a final return.
+ */
+export class InterruptQueue<T> {
+  private items: PendingItem<T>[] = []
+
+  enqueue(promise: Promise<T | null>): void {
+    const item: PendingItem<T> = {promise, settled: false, value: null}
+    promise
+      .then((v) => {
+        item.settled = true
+        item.value = v
+      })
+      .catch(() => {
+        item.settled = true
+        item.value = null
+      })
+    this.items.push(item)
+  }
+
+  /** Non-blocking: collect all settled non-null results and remove them. */
+  drain(): T[] {
+    const results: T[] = []
+    const remaining: PendingItem<T>[] = []
+    for (const item of this.items) {
+      if (item.settled) {
+        if (item.value) results.push(item.value)
+      } else {
+        remaining.push(item)
+      }
+    }
+    this.items = remaining
+    return results
+  }
+
+  /** Blocking: await every pending item then drain. */
+  async flush(): Promise<T[]> {
+    await Promise.allSettled(this.items.map((i) => i.promise))
+    return this.drain()
+  }
+
+  get pending(): number {
+    return this.items.filter((i) => !i.settled).length
+  }
+}

--- a/src/core/session-store.ts
+++ b/src/core/session-store.ts
@@ -1,5 +1,17 @@
 import {randomUUID} from 'node:crypto'
 import type {ChatMessage, LLMProvider} from '../providers/types.js'
+import {InterruptQueue} from './interrupt-queue.js'
+
+export type InterruptMessage = {
+  role: 'tool'
+  content: string
+  toolName: string
+}
+
+export type ReviewConfig = {
+  enabled: boolean
+  tools?: Record<string, string>
+}
 
 export type SessionSummaryBlock = {
   ts: string
@@ -17,10 +29,12 @@ export type AgentSession = {
     maxSteps: number
     contextWindowSize: number
   }
+  reviewConfig: ReviewConfig
   messages: ChatMessage[]
   summaries: SessionSummaryBlock[]
   compressedCount: number
   readPaths: Set<string>
+  interruptQueue: InterruptQueue<InterruptMessage>
 }
 
 export class InMemorySessionStore {

--- a/src/tools/code-review.ts
+++ b/src/tools/code-review.ts
@@ -1,0 +1,185 @@
+import {execa} from 'execa'
+import {readFile, access} from 'node:fs/promises'
+import {extname, join} from 'node:path'
+import type {ReviewConfig} from '../core/session-store.js'
+
+export type {ReviewConfig}
+
+export type ReviewResult = {
+  file: string
+  linter: string
+  output: string
+}
+
+const PER_FILE_LINTERS: Record<string, string> = {
+  '.py': 'ruff check --no-fix',
+  '.js': 'npx eslint',
+  '.ts': 'npx eslint',
+  '.jsx': 'npx eslint',
+  '.tsx': 'npx eslint',
+}
+
+const ESLINT_CONFIG_PATTERNS = [
+  'eslint.config.js',
+  'eslint.config.mjs',
+  'eslint.config.cjs',
+  'eslint.config.ts',
+  '.eslintrc.json',
+  '.eslintrc.js',
+  '.eslintrc.yml',
+  '.eslintrc.yaml',
+  '.eslintrc',
+]
+
+const RUFF_CONFIG_PATTERNS = [
+  'ruff.toml',
+  '.ruff.toml',
+]
+
+function resolveShell(): string | true {
+  if (process.env.SHELL?.trim()) return process.env.SHELL
+  if (process.platform === 'win32') return process.env.ComSpec || 'cmd.exe'
+  return true
+}
+
+async function fileExistsQuiet(path: string): Promise<boolean> {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+type DetectedLint = {
+  command: string
+  linter: string
+  perFile: boolean
+}
+
+const detectionCache = new Map<string, DetectedLint | null>()
+
+/**
+ * Auto-detect lint infrastructure in the workspace.
+ *
+ * Priority:
+ * 1. package.json scripts.lint  (project-level, e.g. "tsc --noEmit")
+ * 2. eslint config file exists  (per-file "npx eslint <file>")
+ * 3. ruff/pyproject.toml exists (per-file "ruff check <file>")
+ */
+async function detectLintSetup(workspace: string): Promise<DetectedLint | null> {
+  if (detectionCache.has(workspace)) return detectionCache.get(workspace)!
+
+  // 1. Check package.json scripts.lint
+  try {
+    const pkgPath = join(workspace, 'package.json')
+    const raw = await readFile(pkgPath, 'utf8')
+    const pkg = JSON.parse(raw) as {scripts?: Record<string, string>}
+    if (pkg.scripts?.lint) {
+      const result: DetectedLint = {
+        command: 'npm run lint',
+        linter: pkg.scripts.lint.split(/\s+/)[0],
+        perFile: false,
+      }
+      detectionCache.set(workspace, result)
+      return result
+    }
+  } catch { /* no package.json or invalid */ }
+
+  // 2. Check eslint config
+  for (const pattern of ESLINT_CONFIG_PATTERNS) {
+    if (await fileExistsQuiet(join(workspace, pattern))) {
+      const result: DetectedLint = {command: 'npx eslint', linter: 'eslint', perFile: true}
+      detectionCache.set(workspace, result)
+      return result
+    }
+  }
+
+  // 3. Check ruff / pyproject.toml
+  for (const pattern of [...RUFF_CONFIG_PATTERNS, 'pyproject.toml']) {
+    if (await fileExistsQuiet(join(workspace, pattern))) {
+      const result: DetectedLint = {command: 'ruff check --no-fix', linter: 'ruff', perFile: true}
+      detectionCache.set(workspace, result)
+      return result
+    }
+  }
+
+  detectionCache.set(workspace, null)
+  return null
+}
+
+function linterForFile(file: string, tools?: Record<string, string>): string | undefined {
+  const ext = extname(file).toLowerCase()
+  if (tools?.[ext]) return tools[ext]
+  return PER_FILE_LINTERS[ext]
+}
+
+/**
+ * Run lint on `filePath` asynchronously.
+ *
+ * Resolution order:
+ * 1. User-configured per-extension tool (config.tools)
+ * 2. Auto-detected project lint (package.json scripts.lint, config files)
+ * 3. Built-in per-file linter defaults
+ *
+ * Returns `null` when the file passes (or no linter applies / binary missing).
+ * Returns a `ReviewResult` only on lint failure.
+ */
+export async function runCodeReview(
+  filePath: string,
+  workspace: string,
+  config?: ReviewConfig
+): Promise<ReviewResult | null> {
+  if (config && !config.enabled) return null
+
+  // 1. User-configured per-extension override
+  const ext = extname(filePath).toLowerCase()
+  const userTool = config?.tools?.[ext]
+  if (userTool) {
+    return runLintCommand(`${userTool} ${filePath}`, filePath, userTool.split(/\s+/)[0], workspace)
+  }
+
+  // 2. Auto-detect project lint setup
+  const detected = await detectLintSetup(workspace)
+  if (detected) {
+    const fullCommand = detected.perFile ? `${detected.command} ${filePath}` : detected.command
+    return runLintCommand(fullCommand, filePath, detected.linter, workspace)
+  }
+
+  // 3. Built-in per-file defaults
+  const defaultCmd = linterForFile(filePath)
+  if (defaultCmd) {
+    return runLintCommand(`${defaultCmd} ${filePath}`, filePath, defaultCmd.split(/\s+/)[0], workspace)
+  }
+
+  return null
+}
+
+async function runLintCommand(
+  fullCommand: string,
+  filePath: string,
+  linter: string,
+  workspace: string,
+): Promise<ReviewResult | null> {
+  try {
+    const {stdout, stderr, exitCode} = await execa(fullCommand, {
+      cwd: workspace,
+      reject: false,
+      shell: resolveShell(),
+    })
+
+    if (exitCode === 0) return null
+
+    const output = [stdout, stderr].filter(Boolean).join('\n').trim()
+    if (!output) return null
+
+    return {file: filePath, linter, output}
+  } catch {
+    return null
+  }
+}
+
+/** Exported for testing. */
+export function clearDetectionCache(): void {
+  detectionCache.clear()
+}

--- a/test/async-code-review.test.ts
+++ b/test/async-code-review.test.ts
@@ -1,0 +1,155 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {unlink, writeFile} from 'node:fs/promises'
+import {existsSync} from 'node:fs'
+
+vi.mock('../src/tools/code-review.js', () => ({
+  runCodeReview: vi.fn(),
+}))
+
+import {runCodeReview} from '../src/tools/code-review.js'
+import {runAgentTask} from '../src/core/agent.js'
+
+function jsonResponse(data: unknown): Response {
+  return new Response(JSON.stringify(data), {
+    status: 200,
+    headers: {'Content-Type': 'application/json'},
+  })
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms))
+}
+
+describe('async code review integration', () => {
+  const targetFile = 'tmp-async-review.ts'
+
+  beforeEach(() => {
+    vi.mocked(runCodeReview).mockReset()
+    process.env.OPENAI_API_KEY = 'test-key'
+  })
+
+  afterEach(async () => {
+    vi.unstubAllGlobals()
+    delete process.env.OPENAI_API_KEY
+    try {
+      if (existsSync(targetFile)) await unlink(targetFile)
+    } catch {
+      /* ignore */
+    }
+  })
+
+  it('injects LINT_FAIL into next turn when review resolves async', async () => {
+    let receivedLintFail = false
+
+    vi.mocked(runCodeReview).mockImplementation(async () => {
+      await delay(30)
+      return {file: targetFile, linter: 'eslint', output: 'error: no-unused-vars'}
+    })
+
+    const fetchMock = vi.fn().mockImplementation(async (_input: unknown, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(String(init.body)) : null
+      const messages: Array<{role: string; content: string}> = body?.messages ?? []
+      const anyHasLintFail = messages.some(
+        (m) => typeof m.content === 'string' && m.content.includes('LINT_FAIL') && m.content.includes(targetFile),
+      )
+      if (anyHasLintFail) receivedLintFail = true
+
+      if (anyHasLintFail) {
+        return jsonResponse({choices: [{message: {content: 'Lint error received and acknowledged.'}}]})
+      }
+
+      const hasWriteResult = messages.some(
+        (m) => typeof m.content === 'string' && m.content.includes('Wrote file') && m.content.includes(targetFile),
+      )
+      if (!hasWriteResult) {
+        return jsonResponse({
+          choices: [
+            {
+              message: {
+                content: `{"type":"tool_call","tool":"write_file","input":{"path":"${targetFile}","content":"const x = 1\\\\n","allowCreate":true}}`,
+              },
+            },
+          ],
+        })
+      }
+
+      return jsonResponse({choices: [{message: {content: 'Task done.'}}]})
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const output = await runAgentTask('create a ts file')
+    expect(output).toContain('Lint error received and acknowledged')
+    expect(receivedLintFail).toBe(true)
+  })
+
+  it('no interrupt when review passes (returns null)', async () => {
+    vi.mocked(runCodeReview).mockImplementation(async () => {
+      await delay(10)
+      return null
+    })
+
+    const fetchMock = vi.fn().mockImplementation(async (_input: unknown, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(String(init.body)) : null
+      const messages: Array<{role: string; content: string}> = body?.messages ?? []
+      const hasLintFail = messages.some((m) => typeof m.content === 'string' && m.content.includes('LINT_FAIL'))
+      if (hasLintFail) {
+        return jsonResponse({choices: [{message: {content: 'Unexpected LINT_FAIL'}}]})
+      }
+      const hasWriteResult = messages.some(
+        (m) => typeof m.content === 'string' && m.content.includes('Wrote file'),
+      )
+      if (!hasWriteResult) {
+        return jsonResponse({
+          choices: [
+            {
+              message: {
+                content: `{"type":"tool_call","tool":"write_file","input":{"path":"${targetFile}","content":"x\\\\n","allowCreate":true}}`,
+              },
+            },
+          ],
+        })
+      }
+      return jsonResponse({choices: [{message: {content: 'Done.'}}]})
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const output = await runAgentTask('create file')
+    expect(output).toContain('Done.')
+    expect(output).not.toContain('Unexpected LINT_FAIL')
+  })
+
+  it('LINT_FAIL via drain when review resolves before model responds', async () => {
+    vi.mocked(runCodeReview).mockImplementation(async () => {
+      await delay(5)
+      return {file: targetFile, linter: 'eslint', output: 'unused'}
+    })
+
+    let sawLintFail = false
+    const fetchMock = vi.fn().mockImplementation(async (_input: unknown, init?: RequestInit) => {
+      const body = init?.body ? JSON.parse(String(init.body)) : null
+      const messages: Array<{role: string; content: string}> = body?.messages ?? []
+      if (messages.some((m) => typeof m.content === 'string' && m.content.includes('LINT_FAIL'))) {
+        sawLintFail = true
+        return jsonResponse({choices: [{message: {content: 'Got lint via drain.'}}]})
+      }
+      const hasWrite = messages.some((m) => typeof m.content === 'string' && m.content.includes('Wrote file'))
+      if (!hasWrite) {
+        return jsonResponse({
+          choices: [
+            {
+              message: {
+                content: `{"type":"tool_call","tool":"write_file","input":{"path":"${targetFile}","content":"y\\\\n","allowCreate":true}}`,
+              },
+            },
+          ],
+        })
+      }
+      return jsonResponse({choices: [{message: {content: 'Done.'}}]})
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const output = await runAgentTask('create file')
+    expect(sawLintFail).toBe(true)
+    expect(output).toContain('Got lint via drain.')
+  })
+})

--- a/test/code-review.test.ts
+++ b/test/code-review.test.ts
@@ -1,0 +1,118 @@
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+vi.mock('execa', () => ({
+  execa: vi.fn(),
+}))
+
+import {execa} from 'execa'
+import {runCodeReview, clearDetectionCache} from '../src/tools/code-review.js'
+
+const execaMock = vi.mocked(execa)
+
+describe('runCodeReview', () => {
+  beforeEach(() => {
+    execaMock.mockReset()
+    clearDetectionCache()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns null when review is disabled', async () => {
+    const result = await runCodeReview('app.py', '/workspace', {enabled: false})
+    expect(result).toBeNull()
+    expect(execaMock).not.toHaveBeenCalled()
+  })
+
+  it('returns null for unsupported file extensions with no project lint', async () => {
+    const result = await runCodeReview('data.csv', '/nonexistent-workspace')
+    expect(result).toBeNull()
+  })
+
+  it('uses custom tool from config when provided', async () => {
+    execaMock.mockResolvedValue({stdout: '', stderr: '', exitCode: 0} as never)
+
+    const result = await runCodeReview('lib.py', '/workspace', {
+      enabled: true,
+      tools: {'.py': 'mypy --strict'},
+    })
+    expect(result).toBeNull()
+    expect(execaMock).toHaveBeenCalledWith(
+      'mypy --strict lib.py',
+      expect.objectContaining({cwd: '/workspace'}),
+    )
+  })
+
+  it('returns ReviewResult on lint failure', async () => {
+    execaMock.mockResolvedValue({
+      stdout: 'app.py:1:1: E302 expected 2 blank lines',
+      stderr: '',
+      exitCode: 1,
+    } as never)
+
+    const result = await runCodeReview('app.py', '/workspace', {
+      enabled: true,
+      tools: {'.py': 'ruff check --no-fix'},
+    })
+    expect(result).not.toBeNull()
+    expect(result!.file).toBe('app.py')
+    expect(result!.linter).toBe('ruff')
+    expect(result!.output).toContain('E302')
+  })
+
+  it('returns null when linter passes (exit 0)', async () => {
+    execaMock.mockResolvedValue({stdout: '', stderr: '', exitCode: 0} as never)
+
+    const result = await runCodeReview('app.ts', '/workspace', {
+      enabled: true,
+      tools: {'.ts': 'npx eslint'},
+    })
+    expect(result).toBeNull()
+  })
+
+  it('returns null when linter binary is not found', async () => {
+    execaMock.mockRejectedValue(new Error('ENOENT'))
+
+    const result = await runCodeReview('app.py', '/workspace', {
+      enabled: true,
+      tools: {'.py': 'ruff check --no-fix'},
+    })
+    expect(result).toBeNull()
+  })
+
+  it('returns null when exit code > 0 but output is empty', async () => {
+    execaMock.mockResolvedValue({stdout: '', stderr: '', exitCode: 2} as never)
+
+    const result = await runCodeReview('app.py', '/workspace', {
+      enabled: true,
+      tools: {'.py': 'ruff check --no-fix'},
+    })
+    expect(result).toBeNull()
+  })
+
+  it('auto-detects npm run lint from package.json in workspace', async () => {
+    execaMock.mockResolvedValue({stdout: '', stderr: '', exitCode: 0} as never)
+
+    const result = await runCodeReview('src/index.ts', process.cwd())
+    expect(result).toBeNull()
+    expect(execaMock).toHaveBeenCalledWith(
+      'npm run lint',
+      expect.objectContaining({cwd: process.cwd()}),
+    )
+  })
+
+  it('auto-detected lint failure returns ReviewResult', async () => {
+    execaMock.mockResolvedValue({
+      stdout: 'src/bad.ts(3,1): error TS2304: Cannot find name "foo".',
+      stderr: '',
+      exitCode: 1,
+    } as never)
+
+    const result = await runCodeReview('src/bad.ts', process.cwd())
+    expect(result).not.toBeNull()
+    expect(result!.file).toBe('src/bad.ts')
+    expect(result!.linter).toBe('tsc')
+    expect(result!.output).toContain('TS2304')
+  })
+})

--- a/test/interrupt-queue.test.ts
+++ b/test/interrupt-queue.test.ts
@@ -1,0 +1,93 @@
+import {describe, expect, it} from 'vitest'
+import {InterruptQueue} from '../src/core/interrupt-queue.js'
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+describe('InterruptQueue', () => {
+  it('drain returns empty when nothing enqueued', () => {
+    const q = new InterruptQueue<string>()
+    expect(q.drain()).toEqual([])
+    expect(q.pending).toBe(0)
+  })
+
+  it('drain collects settled non-null values', async () => {
+    const q = new InterruptQueue<string>()
+    q.enqueue(Promise.resolve('error-a'))
+    q.enqueue(Promise.resolve(null))
+    q.enqueue(Promise.resolve('error-b'))
+
+    await delay(10)
+
+    const results = q.drain()
+    expect(results).toEqual(['error-a', 'error-b'])
+    expect(q.pending).toBe(0)
+  })
+
+  it('drain skips unsettled promises', async () => {
+    const q = new InterruptQueue<string>()
+    q.enqueue(Promise.resolve('fast'))
+    q.enqueue(new Promise((resolve) => setTimeout(() => resolve('slow'), 200)))
+
+    await delay(10)
+
+    const results = q.drain()
+    expect(results).toEqual(['fast'])
+    expect(q.pending).toBe(1)
+  })
+
+  it('flush awaits all pending items then drains', async () => {
+    const q = new InterruptQueue<string>()
+    q.enqueue(new Promise((resolve) => setTimeout(() => resolve('a'), 30)))
+    q.enqueue(new Promise((resolve) => setTimeout(() => resolve(null), 20)))
+    q.enqueue(new Promise((resolve) => setTimeout(() => resolve('b'), 10)))
+
+    const results = await q.flush()
+    expect(results).toEqual(['a', 'b'])
+    expect(q.pending).toBe(0)
+  })
+
+  it('flush returns empty when all pass (resolve to null)', async () => {
+    const q = new InterruptQueue<string>()
+    q.enqueue(Promise.resolve(null))
+    q.enqueue(Promise.resolve(null))
+
+    const results = await q.flush()
+    expect(results).toEqual([])
+  })
+
+  it('rejected promises are treated as null (no interrupt)', async () => {
+    const q = new InterruptQueue<string>()
+    q.enqueue(Promise.reject(new Error('boom')))
+    q.enqueue(Promise.resolve('ok'))
+
+    await delay(10)
+
+    const results = q.drain()
+    expect(results).toEqual(['ok'])
+    expect(q.pending).toBe(0)
+  })
+
+  it('pending tracks unresolved count', async () => {
+    const q = new InterruptQueue<string>()
+    q.enqueue(Promise.resolve('x'))
+    q.enqueue(new Promise((resolve) => setTimeout(() => resolve('y'), 100)))
+
+    await delay(10)
+
+    expect(q.pending).toBe(1)
+    await q.flush()
+    expect(q.pending).toBe(0)
+  })
+
+  it('drain is idempotent — second call returns empty', async () => {
+    const q = new InterruptQueue<string>()
+    q.enqueue(Promise.resolve('once'))
+
+    await delay(10)
+
+    expect(q.drain()).toEqual(['once'])
+    expect(q.drain()).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

Add an alternative async code review flow built on `InterruptQueue` and `runCodeReview`, with a `flush()` step that blocks the agent until all pending reviews are finished before returning.

## Changes

### Core
- **InterruptQueue** (`src/core/interrupt-queue.ts`): Generic queue for async interrupts; `drain()` for non-blocking collection, `flush()` for blocking wait.
- **runCodeReview** (`src/tools/code-review.ts`): Lint via eslint, ruff, or `npm run lint` with auto-detection; supports config per extension via `review.tools`.

### Agent Integration
- After successful `write_file` / `apply_patch`, enqueue a lint promise into `InterruptQueue`.
- At each turn: `drain()` to inject settled results; when the model returns no tool calls, `flush()` to await remaining reviews and inject before returning.
- Ensures lint results are delivered before a one-shot run completes.

### Config
- `review.enabled` / `review.tools` in schema for per-extension overrides.

### Tests
- `interrupt-queue.test.ts`: Queue behavior.
- `code-review.test.ts`: Lint tool behavior.
- `async-code-review.test.ts`: Integration with the agent loop.

## Rationale

- **Reliable one-shot runs**: `flush()` guarantees lint results are injected before returning.
- **Configurable**: `review.tools` allows per-extension linter overrides.
- **Broader tool support**: Supports ruff, eslint, and `npm run lint`, not limited to eslint.