### PR TITLE
修复交互时Ctrl+C循环输出问题

### DIFF
--- a/src/commands/chat.ts
+++ b/src/commands/chat.ts
@@ -211,13 +211,16 @@ export default class Chat extends Command {
 
       this.log(cyan('myclaw chat started. Type /help for commands.'))
 
+      rl.on('SIGINT', () => {
+        this.log(cyan('\nInterrupted. Type /exit to quit.'))
+      })
+
       while (true) {
         let input = ''
         try {
           input = (await rl.question(cyan('you> '))).trim()
         } catch {
-          this.log(cyan('\nInterrupted. Type /exit to quit.'))
-          continue
+          break
         }
 
         if (!input) continue


### PR DESCRIPTION
修复前：
<img width="299" height="515" alt="image" src="https://github.com/user-attachments/assets/b3c7515a-d112-4a55-8947-6e83ba58db01" />
修复后：
<img width="421" height="87" alt="image" src="https://github.com/user-attachments/assets/7a3c7cbb-b1d3-4c58-9de7-ae36e7d7074f" />
